### PR TITLE
feat: Expose new rate structure property

### DIFF
--- a/custom_components/openei/const.py
+++ b/custom_components/openei/const.py
@@ -68,6 +68,11 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
         name="Plan Name",
         icon="mdi:tag",
     ),
+    "current_rate_structure": SensorEntityDescription(
+        key="current_rate_structure",
+        name="Current Rate Structure",
+        icon="mdi:tag",
+    ),
     "all_rates": SensorEntityDescription(
         key="all_rates",
         name="All Listed Rates",

--- a/custom_components/openei/manifest.json
+++ b/custom_components/openei/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/firstof9/ha-openei",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/firstof9/ha-openei/issues",
-  "requirements": ["python-openei==0.1.23"],
+  "requirements": ["python-openei==0.1.24"],
   "version": "0.1.6"
 }

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,5 +1,5 @@
 -r requirements_dev.txt
-python-openei==0.1.22
+python-openei==0.1.24
 pytest
 pytest-cov
 pytest-homeassistant-custom-component

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,7 @@ def mock_api():
             '"Fake Utility Co": [{"name": "Fake Plan Name", "label": "randomstring"}]'
         )
         mock_api.return_value.all_rates = [0.24477, 0.007]
+        mock_api.return_value.current_rate_structure = 4
 
         yield mock_api
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -28,7 +28,7 @@ async def test_setup_entry(hass, mock_sensors, mock_api):
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 6
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 7
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 1
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
@@ -46,14 +46,14 @@ async def test_unload_entry(hass, mock_sensors, mock_api):
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 6
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 7
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 1
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
 
     assert await hass.config_entries.async_unload(entries[0].entry_id)
     await hass.async_block_till_done()
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 6
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 7
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 1
     assert len(hass.states.async_entity_ids(DOMAIN)) == 0
 

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -9,6 +9,7 @@ from tests.const import CONFIG_DATA
 
 FAKE_MINCHARGE_SENSOR = "sensor.fake_utility_co_minimum_charge"
 FAKE_CURRENT_RATE_SENSOR = "sensor.fake_utility_co_current_energy_rate"
+FAKE_CURRENT_RATE_STRUCTURE_SENSOR = "sensor.fake_utility_co_current_rate_structure"
 
 pytestmark = pytest.mark.asyncio
 
@@ -34,3 +35,7 @@ async def test_sensors(hass, mock_sensors, mock_api):
     assert state is not None
     assert state.state == "0.24477"
     assert state.attributes["all_rates"] == [0.24477, 0.007]
+
+    state = hass.states.get(FAKE_CURRENT_RATE_STRUCTURE_SENSOR)
+    assert state is not None
+    assert state.state == "4"


### PR DESCRIPTION
I have a gnarly template in my home assistant config to reverse-calculate the rate name from the current cost, which is kind of a bummer because Jinja floats absolutely suck. 

```Jinja
{% set rates = state_attr('sensor.san_diego_gas_electric_co_current_energy_rate', 'all_rates') | map('round', 3) | list %}
{% set current = states('sensor.san_diego_gas_electric_co_current_energy_rate') | round(3) %}
{% set i = rates.index(current) %}
{% set d = {
  0: "on peak",
  1: "off peak",
  2: "super off peak",
  3: "on peak",
  4: "off peak",
  5: "super off peak",
} %}

{{ d.get(i) }}
```

While I'm sure this template could be better (I'm no Jinja master), I can't see any way around the gross `map('round', 3)` call except to expose the index of the selected rate structure. [SDG&E's EV-TOU-2](https://www.sdge.com/residential/pricing-plans/about-our-pricing-plans/electric-vehicle-plans#DR2) plan has both Summer and Winter periods for On, Off, and Super Off Peak periods.

This PR adds the current_rate_structure from firstof9/python-openei#182 to Home Assistant.
