### PR TITLE
feat: add next rate structure sensors

### DIFF
--- a/custom_components/openei/const.py
+++ b/custom_components/openei/const.py
@@ -73,6 +73,16 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
         name="Current Energy Rate Structure",
         icon="mdi:tag",
     ),
+    "next_energy_rate_structure": SensorEntityDescription(
+        key="next_energy_rate_structure",
+        name="Next Energy Rate Structure",
+        icon="mdi:tag",
+    ),
+    "next_energy_rate_structure_time": SensorEntityDescription(
+        key="next_energy_rate_structure_time",
+        name="Next Energy Rate Structure Time",
+        icon="mdi:clock-outline",
+    ),
     "all_rates": SensorEntityDescription(
         key="all_rates",
         name="All Listed Rates",

--- a/custom_components/openei/manifest.json
+++ b/custom_components/openei/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/firstof9/ha-openei",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/firstof9/ha-openei/issues",
-  "requirements": ["python_openei==0.2.4", "aiofiles"],
+  "requirements": ["python_openei==0.2.5", "aiofiles"],
   "version": "0.1.6"
 }

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -38,7 +38,7 @@ async def test_setup_entry(hass, mock_aioclient, caplog):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-        assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 8
+        assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 10
         assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 1
         entries = hass.config_entries.async_entries(DOMAIN)
         assert len(entries) == 1
@@ -56,14 +56,14 @@ async def test_unload_entry(hass, mock_api):
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 8
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 10
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 1
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
 
     assert await hass.config_entries.async_unload(entries[0].entry_id)
     await hass.async_block_till_done()
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 8
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 10
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 1
     assert len(hass.states.async_entity_ids(DOMAIN)) == 0
 

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -13,6 +13,8 @@ FAKE_CURRENT_RATE_SENSOR = "sensor.fake_utility_co_current_energy_rate"
 FAKE_CURRENT_RATE_STRUCTURE_SENSOR = (
     "sensor.fake_utility_co_current_energy_rate_structure"
 )
+FAKE_NEXT_RATE_SENSOR = "sensor.fake_utility_co_next_energy_rate_structure"
+FAKE_NEXT_RATE_TIME_SENSOR = "sensor.fake_utility_co_next_energy_rate_structure_time"
 
 pytestmark = pytest.mark.asyncio
 
@@ -38,6 +40,12 @@ async def test_sensors(hass, mock_api, caplog):
         assert state.attributes["all_rates"] == [0.24477, 0.06118, 0.19847, 0.06116]
 
         state = hass.states.get(FAKE_CURRENT_RATE_STRUCTURE_SENSOR)
+        assert state is not None
+
+        state = hass.states.get(FAKE_NEXT_RATE_SENSOR)
+        assert state is not None
+
+        state = hass.states.get(FAKE_NEXT_RATE_TIME_SENSOR)
         assert state is not None
 
         state = hass.states.get(FAKE_FIXEDCHARGE_SENSOR)


### PR DESCRIPTION
Implements two new sensors using the changes from this PR https://github.com/firstof9/python-openei/pull/192 in python-openei:
- The next rate structure
- The time the next rate structure will take effect

These values are helpful for planning usage, preconditioning AC, etc.