### PR TITLE
fix: Use fully specified path to storage directory

### DIFF
--- a/custom_components/openei/__init__.py
+++ b/custom_components/openei/__init__.py
@@ -124,7 +124,9 @@ class OpenEIDataUpdateCoordinator(DataUpdateCoordinator):
         api = self._config.data.get(CONF_API_KEY)
         plan = self._config.data.get(CONF_PLAN)
         meter = self._config.data.get(CONF_SENSOR)
-        cache_file = f"{self.hass.config.config_dir}/.storage/openei_{self._config.entry_id}"
+        cache_file = (
+            f"{self.hass.config.config_dir}/.storage/openei_{self._config.entry_id}"
+        )
         reading = None
 
         if self._config.data.get(CONF_MANUAL_PLAN):


### PR DESCRIPTION
When using the linuxserver.io homeassistant container, the current working directory is in /run, so the cache file attempts to write to a directory that's different than the official docker image. Using the hass config_dir property puts the cache_file in the right place.