### PR TITLE
chore: add version-resolver to release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -66,3 +66,18 @@ template: |
 
   ## Links
   - [Submit bugs/feature requests](https://github.com/firstof9/ha-openei/issues)
+
+version-resolver:
+  major:
+    labels:
+      - "breaking-change"
+  minor:
+    labels:
+      - "feature"
+  patch:
+    labels:
+      - "bugfix"
+      - "fix"
+      - "bug"
+      - "chore"
+  default: patch

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -5,13 +5,14 @@ on:
     branches:
       - master
       - dev
-  pull_request:
+  pull_request_target:
     # Only following types are handled by the action, but one can default to all as well
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, edited]
 
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
Adds `version-resolver` block to `.github/release-drafter.yml` to enable semantic auto-versioning based on PR labels (`major`, `minor`, `patch`). Without this block, Release Drafter defaults to incrementing the patch version regardless of the labels applied.

**Additional Fixes to Autolabeler:**
- **Added `issues: write` Permission**: In GitHub's API, adding a label to a pull request uses the Issues API. The workflow was missing this scope, causing silent 403 Forbidden errors when attempting to label.
- **Switched to `pull_request_target`**: The workflow was using the `pull_request` trigger, which downgrades the token to read-only for security reasons when a PR is opened from a fork. Switching to `pull_request_target` ensures the workflow has the necessary permissions to label forks.
- Added the `edited` event type so PRs are relabeled if their titles are updated.