### PR TITLE
test: replace aioresponses with aioclient_mock

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,71 +2,86 @@ name-template: "$RESOLVED_VERSION"
 tag-template: "$RESOLVED_VERSION"
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
 sort-direction: ascending
-autolabeler:
-  - label: "chore"
-    title:
-      - "/chore:/i"
-  - label: "bugfix"
-    title:
-      - "/fix:/i"
-  - label: "feature"
-    title:
-      - "/feat:/i"
-  - label: "enhancement"
-    title:
-      - "/refactor:/i"
-  - label: "code-quality"
-    title:
-      - "/tests:/i"
-  - label: "integration"
-    files:
-      - "custom_components/**/*"
-  - label: "tests"
-    files:
-      - "tests/**/*"
-  - label: "ci"
-    files:
-      - ".github/workflows/**/*"
-      - ".github/release-drafter.yml"
-      - ".pre-commit-config.yaml"
-      - "pyproject.toml"
-  - label: "documentation"
-    files:
-      - "README.md"
-      - "CONTRIBUTING.md"
-      - "info.md"
 categories:
   - title: "💥 Breaking Change 💥"
     labels:
       - "breaking-change"
-  - title: "⚡ Enhancements ⚡"
-    labels:
-      - "enhancement"
   - title: "✨ New Features ✨"
     labels:
+      - "enhancement"
       - "feature"
   - title: "🐛 Bug Fixes 🐛"
     labels:
       - "fix"
       - "bugfix"
       - "bug"
+  - title: "⚡ Performance ⚡"
+    labels:
+      - "performance"
   - title: "🔧 Maintenance 🔧"
     labels:
       - "chore"
+      - "documentation"
+      - "maintenance"
+      - "repo"
+      - "dependencies"
+      - "github_actions"
+      - "style"
+      - "build"
+      - "revert"
+      - "translations"
+    collapse-after: 1
   - title: "🎓 Code Quality 🎓"
     labels:
       - "code-quality"
-  - title: "🔩 Dependency 🔩"
-    labels:
-      - "dependencies"
-template: |
-  [![Downloads for this release](https://img.shields.io/github/downloads/firstof9/ha-openei/$RESOLVED_VERSION/total.svg)](https://github.com/firstof9/ha-openei/releases/$RESOLVED_VERSION)
-
-  $CHANGES
-
-  ## Links
-  - [Submit bugs/feature requests](https://github.com/firstof9/ha-openei/issues)
-
+      - "refactor"
+autolabeler:
+  - label: "breaking-change"
+    title:
+      - '/^[a-z]+(\([^)]+\))?!:/i'
+  - label: "feature"
+    title:
+      - '/^feat(\([^)]+\))?:/i'
+  - label: "bugfix"
+    title:
+      - '/^fix(\([^)]+\))?:/i'
+  - label: "refactor"
+    title:
+      - '/^refactor(\([^)]+\))?:/i'
+  - label: "code-quality"
+    title:
+      - '/^test(\([^)]+\))?:/i'
+  - label: "CI"
+    title:
+      - '/^ci(\([^)]+\))?:/i'
+  - label: "chore"
+    title:
+      - '/^chore(\([^)]+\))?:/i'
+  - label: "documentation"
+    title:
+      - '/^docs(\([^)]+\))?:/i'
+  - label: "style"
+    title:
+      - '/^style(\([^)]+\))?:/i'
+  - label: "performance"
+    title:
+      - '/^perf(\([^)]+\))?:/i'
+  - label: "revert"
+    title:
+      - '/^revert(\([^)]+\))?:/i'
+  - label: "build"
+    title:
+      - '/^build(\([^)]+\))?:/i'
+  - label: "dependencies"
+    title:
+      - "/^build\\(deps\\):/i"
+      - "/^chore\\(deps\\):/i"
+  - label: "has-tests"
+    files:
+      - "tests/**/*"
+  - label: "translations"
+    files:
+      - "custom_components/openei/translations/**/*"
 version-resolver:
   major:
     labels:
@@ -74,10 +89,27 @@ version-resolver:
   minor:
     labels:
       - "feature"
+      - "enhancement"
   patch:
     labels:
-      - "bugfix"
-      - "fix"
       - "bug"
+      - "fix"
+      - "bugfix"
+      - "performance"
+      - "refactor"
+      - "style"
+      - "build"
       - "chore"
+      - "documentation"
+      - "CI"
+      - "test"
+      - "code-quality"
+      - "revert"
   default: patch
+template: |
+  [![Downloads for this release](https://img.shields.io/github/downloads/firstof9/ha-openei/$RESOLVED_VERSION/total.svg)](https://github.com/firstof9/ha-openei/releases/$RESOLVED_VERSION)
+
+  $CHANGES
+
+  ## Links
+  - [Submit bugs/feature requests](https://github.com/firstof9/ha-openei/issues)

--- a/.github/workflows/autolabeler.yaml
+++ b/.github/workflows/autolabeler.yaml
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+# SPDX-License-Identifier: Apache-2.0
+
+name: 'Autolabeler'
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+
+permissions:
+  contents: read
+
+concurrency:
+  # yamllint disable-line rule:line-length
+  group: ${{ format('al-{0}-pr-{1}', github.event_name, github.event.pull_request.number) }}
+  cancel-in-progress: true
+
+jobs:
+  autolabel:
+    name: 'Autolabel PR'
+    # Run on pull_request_target for forks, pull_request for
+    # same-repo PRs to prevent duplicate runs
+    # yamllint disable rule:line-length
+    if: >
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork) ||
+      (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork)
+    # yamllint enable rule:line-length
+    # SECURITY: pull_request_target with write permissions is safe
+    # here because the autolabeler action does NOT checkout any code
+    # from the PR — it only reads the PR title/body via GitHub API.
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 3
+    steps:
+      # Harden the runner used by this workflow
+      # yamllint disable-line rule:line-length
+      - uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: 'audit'
+
+      # yamllint disable-line rule:line-length
+      - uses: release-drafter/release-drafter/autolabeler@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,28 +1,35 @@
-name: Release Drafter
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+# SPDX-License-Identifier: Apache-2.0
 
+name: 'Release Drafter'
+
+# yamllint disable-line rule:truthy
 on:
   push:
     branches:
       - master
-      - dev
-  pull_request_target:
-    # Only following types are handled by the action, but one can default to all as well
-    types: [opened, reopened, synchronize, edited]
 
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   update_release_draft:
-    runs-on: ubuntu-latest
+    name: 'Update Release Draft'
+    permissions:
+      contents: write
+      pull-requests: read
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 3
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      # Harden the runner used by this workflow
+      # yamllint disable-line rule:line-length
+      - uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
-          egress-policy: audit
+          egress-policy: 'audit'
 
-      - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # yamllint disable-line rule:line-length
+      - uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,4 @@ repos:
           - pytest
           - homeassistant
           - types-aiofiles
+          - types-requests

--- a/custom_components/openei/__init__.py
+++ b/custom_components/openei/__init__.py
@@ -8,6 +8,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
@@ -113,6 +114,7 @@ class OpenEIDataUpdateCoordinator(DataUpdateCoordinator):
             plan=plan,
             reading=reading,
             cache_file=cache_file,
+            session=async_get_clientsession(self.hass),
         )
         await rate.update()
 

--- a/custom_components/openei/config_flow.py
+++ b/custom_components/openei/config_flow.py
@@ -11,6 +11,7 @@ from homeassistant import config_entries
 from homeassistant.components.sensor import DOMAIN as SENSORS_DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (
     CONF_API_KEY,
@@ -271,7 +272,14 @@ async def _get_utility_list(hass, user_input) -> list | None:
         lon = hass.config.longitude
         address = None
 
-    plans = openeihttp.Rates(api=api, lat=lat, lon=lon, radius=radius, address=address)
+    plans = openeihttp.Rates(
+        api=api,
+        lat=lat,
+        lon=lon,
+        radius=radius,
+        address=address,
+        session=async_get_clientsession(hass),
+    )
     plans = await _lookup_plans(plans)
     utilities = list(plans.keys())
 
@@ -293,7 +301,14 @@ async def _get_plan_list(hass, user_input) -> list | None:
         lon = hass.config.longitude
         address = None
 
-    plans = openeihttp.Rates(api=api, lat=lat, lon=lon, radius=radius, address=address)
+    plans = openeihttp.Rates(
+        api=api,
+        lat=lat,
+        lon=lon,
+        radius=radius,
+        address=address,
+        session=async_get_clientsession(hass),
+    )
     plans = await _lookup_plans(plans)
     value = {}
 

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -5,6 +5,5 @@ pytest-homeassistant-custom-component
 tox
 ruff
 mypy
-aioresponses
 aiofiles
 prek

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 
 import openeihttp
 import pytest
-from aioresponses import aioresponses
 
 from .common import load_fixture
 
@@ -36,10 +35,9 @@ def skip_notifications_fixture():
 
 
 @pytest.fixture
-def mock_aioclient():
+def mock_aioclient(aioclient_mock):
     """Fixture to mock aioclient calls."""
-    with aioresponses() as m:
-        yield m
+    return aioclient_mock
 
 
 @pytest.fixture(name="mock_api")
@@ -48,8 +46,7 @@ def mock_plandata(mock_aioclient):
     mock_aioclient.get(
         re.compile(TEST_PATTERN),
         status=200,
-        body=load_fixture("plan_data.json"),
-        repeat=True,
+        text=load_fixture("plan_data.json"),
     )
 
 
@@ -59,8 +56,7 @@ def mock_rate_limit(mock_aioclient):
     mock_aioclient.get(
         re.compile(TEST_PATTERN),
         status=200,
-        body=load_fixture("rate_limit.json"),
-        repeat=True,
+        text=load_fixture("rate_limit.json"),
     )
 
 
@@ -70,8 +66,7 @@ def mock_lookup(mock_aioclient):
     mock_aioclient.get(
         re.compile(TEST_PATTERN),
         status=200,
-        body=load_fixture("lookup.json"),
-        repeat=True,
+        text=load_fixture("lookup.json"),
     )
 
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -161,8 +161,7 @@ async def test_reconfig_form(
     mock_aioclient.get(
         re.compile(TEST_PATTERN),
         status=200,
-        body=load_fixture("plan_data.json"),
-        repeat=True,
+        text=load_fixture("plan_data.json"),
     )
 
     entry.add_to_hass(hass)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -28,8 +28,7 @@ async def test_setup_entry(hass, mock_aioclient, caplog):
     mock_aioclient.get(
         re.compile(TEST_PATTERN),
         status=200,
-        body=load_fixture("plan_data.json"),
-        repeat=True,
+        text=load_fixture("plan_data.json"),
     )
 
     with caplog.at_level(logging.DEBUG):


### PR DESCRIPTION
Replace `aioresponses` with `aioclient_mock` in the test suite. Additionally, update the integration to pass the client session to `openeihttp.Rates` so requests can be intercepted properly by the mock client session helper, and add `types-requests` to `pre-commit` additional dependencies to fix type checking in hooks.