### PR TITLE
chore: migrate release-drafter configuration to new schema (PR #1558)

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -3,109 +3,101 @@ tag-template: "$RESOLVED_VERSION"
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
 sort-direction: ascending
 categories:
+  # 1. Version Resolver Categories (New Schema)
+  - type: "version-resolver"
+    when:
+      labels:
+        - "breaking-change"
+    semver-increment: "major"
+
+  - type: "version-resolver"
+    when:
+      labels:
+        - "feature"
+    semver-increment: "minor"
+
+  - type: "version-resolver"
+    when:
+      labels:
+        - "bugfix"
+        - "fix"
+        - "bug"
+        - "chore"
+    semver-increment: "patch"
+
+  - type: "version-resolver"
+    semver-increment: "patch" # Default fallback
+
+  # 2. Changelog Grouping Categories (Updated 'when' syntax)
   - title: "💥 Breaking Change 💥"
-    labels:
-      - "breaking-change"
+    when:
+      labels:
+        - "breaking-change"
+
+  - title: "⚡ Enhancements ⚡"
+    when:
+      labels:
+        - "enhancement"
+
   - title: "✨ New Features ✨"
-    labels:
-      - "enhancement"
-      - "feature"
+    when:
+      labels:
+        - "feature"
+
   - title: "🐛 Bug Fixes 🐛"
-    labels:
-      - "fix"
-      - "bugfix"
-      - "bug"
-  - title: "⚡ Performance ⚡"
-    labels:
-      - "performance"
+    when:
+      labels:
+        - "fix"
+        - "bugfix"
+        - "bug"
+
   - title: "🔧 Maintenance 🔧"
-    labels:
-      - "chore"
-      - "documentation"
-      - "maintenance"
-      - "repo"
-      - "dependencies"
-      - "github_actions"
-      - "style"
-      - "build"
-      - "revert"
-      - "translations"
-    collapse-after: 1
+    when:
+      labels:
+        - "chore"
+
   - title: "🎓 Code Quality 🎓"
-    labels:
-      - "code-quality"
-      - "refactor"
+    when:
+      labels:
+        - "code-quality"
+
+  - title: "🔩 Dependency 🔩"
+    when:
+      labels:
+        - "dependencies"
 autolabeler:
-  - label: "breaking-change"
-    title:
-      - '/^[a-z]+(\([^)]+\))?!:/i'
-  - label: "feature"
-    title:
-      - '/^feat(\([^)]+\))?:/i'
-  - label: "bugfix"
-    title:
-      - '/^fix(\([^)]+\))?:/i'
-  - label: "refactor"
-    title:
-      - '/^refactor(\([^)]+\))?:/i'
-  - label: "code-quality"
-    title:
-      - '/^test(\([^)]+\))?:/i'
-  - label: "CI"
-    title:
-      - '/^ci(\([^)]+\))?:/i'
   - label: "chore"
     title:
-      - '/^chore(\([^)]+\))?:/i'
-  - label: "documentation"
+      - "/chore:/i"
+  - label: "bugfix"
     title:
-      - '/^docs(\([^)]+\))?:/i'
-  - label: "style"
+      - "/fix:/i"
+  - label: "feature"
     title:
-      - '/^style(\([^)]+\))?:/i'
-  - label: "performance"
+      - "/feat:/i"
+  - label: "enhancement"
     title:
-      - '/^perf(\([^)]+\))?:/i'
-  - label: "revert"
+      - "/refactor:/i"
+  - label: "code-quality"
     title:
-      - '/^revert(\([^)]+\))?:/i'
-  - label: "build"
-    title:
-      - '/^build(\([^)]+\))?:/i'
-  - label: "dependencies"
-    title:
-      - "/^build\\(deps\\):/i"
-      - "/^chore\\(deps\\):/i"
-  - label: "has-tests"
+      - "/tests:/i"
+  - label: "integration"
+    files:
+      - "custom_components/**/*"
+  - label: "tests"
     files:
       - "tests/**/*"
-  - label: "translations"
+  - label: "ci"
     files:
-      - "custom_components/openei/translations/**/*"
-version-resolver:
-  major:
-    labels:
-      - "breaking-change"
-  minor:
-    labels:
-      - "feature"
-      - "enhancement"
-  patch:
-    labels:
-      - "bug"
-      - "fix"
-      - "bugfix"
-      - "performance"
-      - "refactor"
-      - "style"
-      - "build"
-      - "chore"
-      - "documentation"
-      - "CI"
-      - "test"
-      - "code-quality"
-      - "revert"
-  default: patch
+      - ".github/workflows/**/*"
+      - ".github/release-drafter.yml"
+      - ".pre-commit-config.yaml"
+      - "pyproject.toml"
+  - label: "documentation"
+    files:
+      - "README.md"
+      - "CONTRIBUTING.md"
+      - "info.md"
 template: |
   [![Downloads for this release](https://img.shields.io/github/downloads/firstof9/ha-openei/$RESOLVED_VERSION/total.svg)](https://github.com/firstof9/ha-openei/releases/$RESOLVED_VERSION)
 

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -69,6 +69,9 @@ autolabeler:
   - label: "chore"
     title:
       - "/chore:/i"
+  - label: "breaking-change"
+    title:
+      - "/^[a-z]+(\\([^)]+\\))?!:/i"
   - label: "bugfix"
     title:
       - "/fix:/i"
@@ -81,12 +84,6 @@ autolabeler:
   - label: "code-quality"
     title:
       - "/tests:/i"
-  - label: "integration"
-    files:
-      - "custom_components/**/*"
-  - label: "tests"
-    files:
-      - "tests/**/*"
   - label: "ci"
     files:
       - ".github/workflows/**/*"


### PR DESCRIPTION
Migrate release-drafter configuration to the new schema defined in PR #1558, unifying categories and moving version resolution into the `categories` block. This also updates the workflow to pin release-drafter to v7.4.0.